### PR TITLE
allow chunked sending of seed files

### DIFF
--- a/elasticsearch-rake-tasks.gemspec
+++ b/elasticsearch-rake-tasks.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "faraday"
   spec.add_dependency "eson"
   spec.add_dependency "eson-more"
   spec.add_dependency "active_support"

--- a/lib/elasticsearch-rake-tasks.rake
+++ b/lib/elasticsearch-rake-tasks.rake
@@ -1,5 +1,5 @@
 require "json"
-require "elasticsearch/helpers"
+require "elasticsearch-rake-tasks"
 
 BASE_PATH = "resources/elasticsearch/"
 TEMPLATES_PATH = "#{BASE_PATH}templates/"
@@ -27,7 +27,10 @@ namespace :es do
     validate_elasticsearch_configuration!(server, index)
 
     raise "need seed data in #{SEED_PATH}seed.json" unless File.exist?("#{SEED_PATH}seed.json")
-    Elasticsearch::Helpers.curl_request("POST", "#{server}/#{index}/_bulk", "--data-binary @#{SEED_PATH}seed.json")
+    sender = Elasticsearch::Helpers::ChunkedSender.new("#{server}/#{index}/_bulk")
+    File.open("#{SEED_PATH}seed.json", "rb") do |io|
+      sender.send io
+    end
   end
 
   desc "Dump the elasticsearch index to the seed file"

--- a/lib/elasticsearch-rake-tasks.rb
+++ b/lib/elasticsearch-rake-tasks.rb
@@ -1,0 +1,2 @@
+require_relative "elasticsearch/helpers"
+require_relative "elasticsearch/helpers/chunked_sender"

--- a/lib/elasticsearch/helpers/chunked_sender.rb
+++ b/lib/elasticsearch/helpers/chunked_sender.rb
@@ -1,0 +1,51 @@
+require "faraday"
+
+module Elasticsearch
+  module Helpers
+    class ChunkedSender
+
+      attr_accessor :target_url, :opts
+      
+      @conn = nil
+
+      def initialize(target_url, opts = {})
+        default_opts = {:max_bytes => 1024 * 1024 * 10} # 10MB
+        self.target_url = target_url
+        self.opts = default_opts.merge(opts)
+      end
+
+      def send(io)
+        send_buffer = ''
+        buffer = ''
+        counter = 0
+        io.each_line do |line|
+          counter += 1 
+          buffer << line
+          if 0 == (counter % 2)
+            if (send_buffer.bytesize + buffer.bytesize) < opts[:max_bytes]
+              send_buffer << buffer
+            else
+              send_bytes(send_buffer)
+              send_buffer = buffer
+            end
+            buffer = ''
+          end
+        end
+        send_bytes(send_buffer)
+      end
+
+      def send_bytes(buffer)
+        connection.post '', buffer      
+      end
+
+      def connection
+        @conn ||= Faraday.new(:url => target_url) do |faraday|
+          faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
+        end
+        @conn
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
elasticsearch limits the upload size for bulk indexing operations. Now
we don't attempt to send the whole seed file in one go but rather send
chunks well below that limit.
