### PR TITLE
Adjusted gem dependency of active_support

### DIFF
--- a/elasticsearch-rake-tasks.gemspec
+++ b/elasticsearch-rake-tasks.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "eson"
   spec.add_dependency "eson-more"
-  spec.add_dependency "active_support", '~> 3.2.0'
+  spec.add_dependency "activesupport", '~> 3.2.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Exchanged the gem depedency `active_support` with `activesupport`. The former is an older gem and not maintained anymore, but has a strict dependency to the letter (= v 3.0.0).
