### PR TITLE
Added a combined rake task for creating and updating an index

### DIFF
--- a/lib/elasticsearch-rake-tasks.rake
+++ b/lib/elasticsearch-rake-tasks.rake
@@ -142,6 +142,19 @@ namespace :es do
         client = Eson::HTTP::Client.new(:server => server)
         update_alias(client, name, index)
       end
+
+      desc "Updates the index to a new version with template #{name}"
+      task :flip, :server, :old_index, :new_index do |t,args|
+        args.with_defaults(:server => @es_server)
+
+        server    = args[:server]
+        old_index = args[:old_index]
+        new_index = args[:new_index]
+
+        Rake::Task["es:#{name}:create"].invoke(server, new_index)
+        Rake::Task["es:reindex"].invoke(server, old_index, new_index)
+        Rake::Task["es:#{name}:alias"].invoke(server, new_index)
+      end
     end
   end
 end


### PR DESCRIPTION
Adds a new rake task to execute the steps `create`, `reindex` and `alias` in one command.

Use `es:template:flip` to create a new index with the given template. This includes reindexing into the new index from the old one and sets the alias to the template name.
