### PR TITLE
Allows to disable getting default attributes for a type

### DIFF
--- a/lib/elasticsearch/helpers.rb
+++ b/lib/elasticsearch/helpers.rb
@@ -60,7 +60,11 @@ module Elasticsearch
           paths.each do |p|
             name, _ = p.split(".")
             content = read_and_parse_file p
-            mappings[name] = default.deep_merge(content)
+            if content.fetch('inherit', true)
+              mappings[name] = default.deep_merge(content)
+            else
+              mappings[name] = content
+            end
           end
         end
 


### PR DESCRIPTION
There was use case where not inheriting default attributes for a specific type became necessary. This is to not clutter types that do not really share basic attributes with most others.

Use the following declaration to disable the inheritance for a specific type.

```

---
inherit: false
```

This is non-invasive change, all existing uses should not be affected by this. This allows to annotate a type explicitly to not get attributes from the type defined in the `_default.*` file.
