### PR TITLE
[WIP] Rake task added to delete index

### DIFF
--- a/lib/elasticsearch-rake-tasks.rake
+++ b/lib/elasticsearch-rake-tasks.rake
@@ -133,10 +133,10 @@ namespace :es do
         validate_elasticsearch_configuration!(server, index)
         reader = Elasticsearch::Helpers::Reader.new TEMPLATES_PATH
 
-        url = "#{server}/#{index}/"
-        Elasticsearch::Helpers.curl_request("PUT", url)
         url = "#{server}/_template/#{index}/"
         Elasticsearch::Helpers.curl_request("PUT", url, "-d #{Shellwords.escape(reader.compile_template(name))}")
+        url = "#{server}/#{index}/"
+        Elasticsearch::Helpers.curl_request("PUT", url)
       end
 
       desc "Sets an alias to a specific index"


### PR DESCRIPTION
Rake task added to delete an existing index, should only be called when the index is of no further use, e.g. after reindexing.
