### PR TITLE
Use Eson client instead of helper function in rake tasks

### DIFF
--- a/lib/elasticsearch-rake-tasks.rake
+++ b/lib/elasticsearch-rake-tasks.rake
@@ -90,7 +90,7 @@ namespace :es do
       desc "Compile the #{name} template and prints it to STDOUT"
       task :compile do
         reader = Elasticsearch::Helpers::Reader.new TEMPLATES_PATH
-        puts reader.compile_template_to_string(name)
+        puts JSON.dump reader.compile_template(name)
       end
 
       desc "Deletes the #{name} template and recreates it"

--- a/lib/elasticsearch/helpers.rb
+++ b/lib/elasticsearch/helpers.rb
@@ -74,10 +74,6 @@ module Elasticsearch
         end
       end
 
-      def compile_template_to_string(name)
-        JSON.dump compile_template name
-      end
-
       def compile_template(name)
         require 'active_support/core_ext/hash/deep_merge'
         mappings = read_mappings(name)


### PR DESCRIPTION
This PR removes the `curl_request` helper function from rake tasks, the [Eson HTTP](https://github.com/Asquera/eson) client is used to create / remove templates and indexes.
