### PR TITLE
Refactored and split create index rake task

### DIFF
--- a/lib/elasticsearch-rake-tasks.rake
+++ b/lib/elasticsearch-rake-tasks.rake
@@ -87,6 +87,17 @@ namespace :es do
         puts JSON.dump reader.compile_template(name)
       end
 
+      desc "Compiles and uploads the #{name} template"
+      task :create, :server, :template do |t, args|
+        args.with_defaults(:server => @es_server, :template => name)
+
+        reader  = Elasticsearch::Helpers::Reader.new TEMPLATES_PATH
+        content = reader.compile_template(name)
+        client  = Eson::HTTP::Client.new(:server => args[:server])
+
+        client.put_template content.merge(name: args[:template])
+      end
+
       desc "Deletes the #{name} template and recreates it"
       task :reset, :server do |t, args|
         args.with_defaults(:server => @es_server)


### PR DESCRIPTION
The create index rake task is split into two steps, creating the index and uploading a template.
- create index rake task moved outside the template specific namespace
- the upload template rake task can store a given template under a different name, can be left blank to use the template name
- occurrences of `curl_request` calls changed to use Eson client
