### PR TITLE
Fixes create index task, template key is removed

### DIFF
--- a/lib/elasticsearch-rake-tasks.rake
+++ b/lib/elasticsearch-rake-tasks.rake
@@ -121,6 +121,7 @@ namespace :es do
         args.with_defaults(:server => @es_server)
 
         esclient_with_template(name, args[:server]) do |client, content|
+          content.delete('template')
           log_info "Creating index #{args[:index]} with template '#{name}' at '#{args[:server]}'"
           client.create_index content.merge(index: args[:index])
         end


### PR DESCRIPTION
Template keyword is removed from argument hash when creating ES index.
