### PR TITLE
Change color_enabled to color

### DIFF
--- a/elasticsearch-rake-tasks.gemspec
+++ b/elasticsearch-rake-tasks.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.2"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ Bundler.setup
 require 'elasticsearch-rake-tasks.rb'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
   config.formatter     = 'documentation'
 end
 


### PR DESCRIPTION
When using rspec 3.2.1 the tests do not run and raise the following error:

```
spec/spec_helper.rb:7:in `block in <top (required)>': undefined method `color_enabled=' for #<RSpec::Core::Configuration:0x007ff73a1abbf0> (NoMethodError)
```

This PR fixes this by changing `color_enabled` to `color`.